### PR TITLE
Don't iterate over closed shard in snapshotter

### DIFF
--- a/snapshotter.go
+++ b/snapshotter.go
@@ -326,8 +326,6 @@ func (s *ShardSnapshotter) UpdateSnapshot(tx *bolt.Tx, startingAfter string) (st
 			}
 		}
 	}
-
-	return "", errors.New("unreachable reached")
 }
 
 func (s *ShardSnapshotter) FromWorkingCopy(file string, snapshot Snapshot) error {


### PR DESCRIPTION
Similar error to query. In this case if there's no more iterator (stream is closed) we can just bail out.

/cc @sclasen 