### PR TITLE
use `bolt compact` to make working copies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,11 +48,13 @@ snapshotter := &ShardSnapshotter{
 				ShardId:        shardId,
 				DoneLag:        10,
 				Generator:      &MySnapshotGen{},
+				CompactDB:      true,
 			}
 
 //finds/downloads latest snapshot, or bootstraps it.
 //updates the snapshot until the kinesis consumer is caught up.
 //uploads the new latest snapshot.
+//NOTE: if you set CompactDB to true, you must have the `bolt` binary in your path to successfully snapshot.
 snapshotter.SnapshotShard()
 
 ```

--- a/snapshotter.go
+++ b/snapshotter.go
@@ -349,6 +349,7 @@ func (s *ShardSnapshotter) FromWorkingCopy(file string, snapshot Snapshot) error
 		}
 		log.Printf("component=shard-snapshotter fn=from-working-copy at=compaction-error status=fallback-to-simple-mv error=%q", compactErr)
 	}
+	log.Println("component=shard-snapshotter fn=from-working-copy at=simple-mv")
 	return exec.Command("mv", file, snapshot.LocalFile).Run()
 }
 

--- a/snapshotter.go
+++ b/snapshotter.go
@@ -209,7 +209,7 @@ func (s *ShardSnapshotter) BootstrapSnapshot() (*Snapshot, error) {
 		return nil, err
 	}
 
-	return &snapshot, s.FromWorkingCopy(init.LocalFile, snapshot)
+	return &snapshot, nil
 }
 
 func (s *ShardSnapshotFinder) DownloadSnapshot(snapshot Snapshot) error {
@@ -340,6 +340,7 @@ func (s *ShardSnapshotter) UpdateSnapshot(tx *bolt.Tx, startingAfter string) (st
 func (s *ShardSnapshotter) FromWorkingCopy(file string, snapshot Snapshot) error {
 	log.Println("component=shard-snapshotter fn=from-working-copy at=start")
 	if s.CompactDB {
+		log.Println("component=shard-snapshotter fn=from-working-copy at=compact")
 		compactErr := exec.Command("bolt", "compact", "-o", snapshot.LocalFile, file).Run()
 		if compactErr == nil {
 			ss, serr := os.Stat(file)

--- a/snapshotter.go
+++ b/snapshotter.go
@@ -234,9 +234,10 @@ func (s *ShardSnapshotter) ToWorkingCopy(snapshot Snapshot) (string, error) {
 	if s.CompactDB {
 		compactErr := exec.Command("bolt", "compact", "-o", copy, snapshot.LocalFile).Run()
 		if compactErr == nil {
+			log.Println("component=shard-snapshotter fn=to-working-copy at=compacted-working-copy")
 			return copy, nil
 		}
-		log.Printf("component=shard-snapshotter fn=download-snapshot at=compaction-error status=fallback-to-simple-copy error=%q", compactErr)
+		log.Printf("component=shard-snapshotter fn=to-working-copy at=compaction-error status=fallback-to-simple-copy error=%q", compactErr)
 	}
 	return copy, exec.Command("mv", snapshot.LocalFile, copy).Run()
 

--- a/snapshotter.go
+++ b/snapshotter.go
@@ -234,7 +234,19 @@ func (s *ShardSnapshotter) ToWorkingCopy(snapshot Snapshot) (string, error) {
 	if s.CompactDB {
 		compactErr := exec.Command("bolt", "compact", "-o", copy, snapshot.LocalFile).Run()
 		if compactErr == nil {
-			log.Println("component=shard-snapshotter fn=to-working-copy at=compacted-working-copy")
+			ss, serr := os.Stat(snapshot.LocalFile)
+			ds, derr := os.Stat(copy)
+			before := int64(-1)
+			after := int64(-1)
+			if serr == nil {
+				before = ss.Size()
+			}
+			if derr == nil {
+				after = ds.Size()
+			}
+
+			log.Printf("component=shard-snapshotter fn=to-working-copy at=compacted-working-copy size-before=%d size-after=%d", before, after)
+
 			return copy, nil
 		}
 		log.Printf("component=shard-snapshotter fn=to-working-copy at=compaction-error status=fallback-to-simple-copy error=%q", compactErr)

--- a/snapshotter_test.go
+++ b/snapshotter_test.go
@@ -7,16 +7,16 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/boltdb/bolt"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
-	"os/exec"
-	"io/ioutil"
 )
 
 func TestSnapshots(t *testing.T) {
@@ -357,36 +357,75 @@ func (s *TestSnapshotGen) OnRecords(tx *bolt.Tx, gro *kinesis.GetRecordsOutput) 
 }
 
 func TestCompactingLocalCopy(t *testing.T) {
-	if testDB := os.Getenv("COPMACTION_TEST_DB"); testDB != "" {
-		source, _ := ioutil.TempFile("","")
-		destDir, _ := ioutil.TempDir("","")
-		exec.Command("cp", testDB, source.Name()).Run()
-		snap := &ShardSnapshotter{
-			LocalPath:destDir,
-			Stream:"stream",
-			ShardId:"shard",
-			CompactDB: true,
-		}
+	testDB := os.Getenv("COPMACTION_TEST_DB")
 
-		dest, err := snap.ToWorkingCopy(Snapshot{LocalFile:source.Name()})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		ss, err := os.Stat(source.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-		ds, err := os.Stat(dest)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("compacted source-size=%d dest-size=%d", ss.Size(), ds.Size())
-
-		if ds.Size() >= ss.Size() {
-			t.Fatal("compression produced no improvement, did the source DB have any deleted keys ever?")
-		}
+	if testDB == "" {
+		testDB = compactionTestDB()
+	} else {
+		log.Printf("Using COMPACTION_TEST_DB")
 	}
+
+	source, _ := ioutil.TempFile("", "")
+	destDir, _ := ioutil.TempDir("", "")
+	exec.Command("cp", testDB, source.Name()).Run()
+	snap := &ShardSnapshotter{
+		LocalPath: destDir,
+		Stream:    "stream",
+		ShardId:   "shard",
+		CompactDB: true,
+	}
+
+	ss := snap.Finder().SnapshotFromKinesisSeq(BootstrapSequence)
+
+	err := snap.FromWorkingCopy(source.Name(), ss)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src, err := os.Stat(source.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ds, err := os.Stat(ss.LocalFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("compacted source-size=%d dest-size=%d", src.Size(), ds.Size())
+
+	if ds.Size() >= src.Size() {
+		t.Fatal("compression produced no improvement, did the source DB have any deleted keys ever?")
+	}
+
 }
 
+func compactionTestDB() string {
+	dbf, err := ioutil.TempFile("", "")
+	db, err := bolt.Open(dbf.Name(), 0600, nil)
+
+	if err != nil {
+		panic(err)
+	}
+
+	db.Update(func(tx *bolt.Tx) error {
+		data, err := tx.CreateBucketIfNotExists([]byte("data"))
+		if err != nil {
+			panic(err)
+		}
+		//fill up db
+		for i := 0; i < 100000; i++ {
+			datum := []byte(fmt.Sprintf("datum-%d", i))
+			data.Put(datum, datum)
+		}
+		//delete half
+		for i := 0; i < 100000; i += 2 {
+			datum := []byte(fmt.Sprintf("datum-%d", i))
+			data.Delete(datum)
+		}
+		return nil
+	})
+
+	log.Println("wrote compaction test db")
+	db.Close()
+	return dbf.Name()
+}

--- a/snapshotter_test.go
+++ b/snapshotter_test.go
@@ -116,6 +116,7 @@ func TestIntegration(t *testing.T) {
 				ShardId:        *o.StreamDescription.Shards[0].ShardId,
 				DoneLag:        10,
 				Generator:      &TestSnapshotGen{},
+				CompactDB:      true,
 			}
 			break
 		}
@@ -428,4 +429,19 @@ func compactionTestDB() string {
 	log.Println("wrote compaction test db")
 	db.Close()
 	return dbf.Name()
+}
+
+func TestBootstrapWithCompaction(t *testing.T) {
+	local, _ := ioutil.TempDir("", "local")
+	s := &ShardSnapshotter{
+		Stream:       "my-stream-name",
+		ShardId:      "shardId-000000000000",
+		SnapshotPath: "snapshots",
+		LocalPath:    local,
+		Generator:    &TestSnapshotGen{},
+		CompactDB:    true,
+
+	}
+
+	s.BootstrapSnapshot()
 }


### PR DESCRIPTION
 config option to use `bolt compact`rather than simple copies to make a working copy.

Compacts free space so dbs dont get bloated with deleted keys.

